### PR TITLE
Create diff dir if not found

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const pixelmatch = require("pixelmatch");
 const { PNG } = require("pngjs");
+const mkdirp = require("mkdirp");
 const decodePng = require("./decode-png");
 const decodeJpeg = require("./decode-jpeg");
 const decodeTiff = require("./decode-tiff");
@@ -49,6 +50,7 @@ function compare(img1, img2, diffFilename, options) {
     return Promise.resolve(result);
   }
 
+  mkdirp.sync(path.dirname(diffFilename));
   const out = fs.createWriteStream(diffFilename);
   const p = new Promise((resolve, reject) => {
     out


### PR DESCRIPTION
Hi. I met the following error:

```
Error: ENOENT: no such file or directory, open 'foo/bar/foobar.png'   at Error (native)
```

It probably is an error that occurs when there is no diff image directory.
